### PR TITLE
Fix conflict with simplito/bigint-wrapper-php

### DIFF
--- a/src/EcRecover.php
+++ b/src/EcRecover.php
@@ -17,7 +17,7 @@ class EcRecover
      */
     public static function personalEcRecover(string $message, string $signature)
     {
-        $message_hash =  '0x' . Keccak::hash(self::personalSignAddHeader($message), 256);
+        $message_hash = Keccak::hash(self::personalSignAddHeader($message), 256);
         $address = self::phpEcRecover($message_hash, $signature);
         return $address;
     }


### PR DESCRIPTION
This is the fix for the problem described in issue #2.

All unit tests continue to pass with this fix in place, both on platforms using gmp and on those using bcmath instead.